### PR TITLE
fix: EmojiDefinition type import

### DIFF
--- a/src/runtime/components/Twemoji.vue
+++ b/src/runtime/components/Twemoji.vue
@@ -2,7 +2,7 @@
 <script setup lang="ts">
 import { ref, computed, defineComponent, h, watchEffect } from 'vue'
 import { useState } from '#imports'
-import { EmojiDefinition } from './../assets/emojis'
+import type { EmojiDefinition } from './../assets/emojis'
 
 const props = defineProps({
   emoji: {


### PR DESCRIPTION
in nuxt release version [3.8.0](https://nuxt.com/blog/v3-8) type import must be explicit 