### PR TITLE
fix: strip `VS16` modifiers from emojis in `Twemojify`

### DIFF
--- a/src/runtime/components/Twemoji.vue
+++ b/src/runtime/components/Twemoji.vue
@@ -5,6 +5,7 @@ import { toCodePoints } from '@twemoji/parser'
 import type { NuxtTwemojiRuntimeOptions } from '../../types'
 import type { EmojiDefinition } from '../assets/emojis'
 import { useState, useRuntimeConfig } from '#imports'
+import { removeVS16s } from '../utils/parsing'
 
 const props = withDefaults(defineProps<{
   /**
@@ -52,12 +53,6 @@ const isHex = computed(() => (/^[0-9A-F]{1,6}(?:-[0-9A-F]{1,6})*$/i).test(twemoj
 
 const codePoint = ref<{ [key: string]: string }>({})
 const isFetching = ref(false)
-
-const vs16RegExp = /\uFE0F/g
-const zeroWidthJoiner = String.fromCharCode(0x200D)
-const removeVS16s = (rawEmoji: string) => {
-  return !rawEmoji.includes(zeroWidthJoiner) ? rawEmoji.replace(vs16RegExp, '') : rawEmoji
-}
 
 const parsed = computed(() => {
   if (isHex.value) return twemoji.value

--- a/src/runtime/components/Twemoji.vue
+++ b/src/runtime/components/Twemoji.vue
@@ -5,7 +5,6 @@ import { toCodePoints } from '@twemoji/parser'
 import type { NuxtTwemojiRuntimeOptions } from '../../types'
 import type { EmojiDefinition } from '../assets/emojis'
 import { useState, useRuntimeConfig } from '#imports'
-import { removeVS16s } from '../utils/parsing'
 
 const props = withDefaults(defineProps<{
   /**
@@ -53,6 +52,11 @@ const isHex = computed(() => (/^[0-9A-F]{1,6}(?:-[0-9A-F]{1,6})*$/i).test(twemoj
 
 const codePoint = ref<{ [key: string]: string }>({})
 const isFetching = ref(false)
+const vs16RegExp = /\uFE0F/g
+const zeroWidthJoiner = String.fromCharCode(0x200D)
+const removeVS16s = (rawEmoji: string) => {
+  return !rawEmoji.includes(zeroWidthJoiner) ? rawEmoji.replace(vs16RegExp, '') : rawEmoji
+}
 
 const parsed = computed(() => {
   if (isHex.value) return twemoji.value

--- a/src/runtime/components/Twemojify.vue
+++ b/src/runtime/components/Twemojify.vue
@@ -4,6 +4,7 @@ import { ref, computed, watch } from 'vue'
 import { parse } from '@twemoji/parser'
 import type { NuxtTwemojiRuntimeOptions } from '../../types'
 import { useState, useRuntimeConfig } from '#imports'
+import { removeVS16s } from '../utils/parsing'
 
 const props = defineProps<{
   /**
@@ -22,16 +23,25 @@ const renderMode = computed(() => props.mode !== undefined ? props.mode : config
 const twemojify = useState(`twemojify:${renderMode.value}`, () => ({}) as Record<string, string>)
 const parsedText = ref(props.text)
 
-const replaceEmojis = (emoji: string, indices: number[]) => {
+const replaceEmojis = (emoji: string, indices: number[], source: string) => {
   if (!twemojify.value[emoji]) return parsedText.value
-  return parsedText.value.replace(props.text.slice(...indices), twemojify.value[emoji])
+  return parsedText.value.replace(source.slice(...indices), twemojify.value[emoji])
 }
 
 const loadTwemojify = async () => {
+  const trimmed = removeVS16s(props.text)
+  console.log('props.text: ', props.text)
+  parsedText.value = trimmed
+
   const emojis = parse(props.text, { assetType: renderMode.value })
+  console.log('emojis: ', emojis)
+
   for (const { url, indices, text: emoji } of emojis) {
+    console.log('url: ', url)
+    if (!url) continue
+
     if (twemojify.value[emoji]) {
-      parsedText.value = replaceEmojis(emoji, indices)
+      parsedText.value = replaceEmojis(emoji, indices, trimmed)
       continue
     }
 
@@ -50,7 +60,7 @@ const loadTwemojify = async () => {
           const cached = localStorage.getItem(`twemojify-${emoji}`)
           if (cached) {
             twemojify.value[emoji] = cached
-            parsedText.value = replaceEmojis(emoji, indices)
+            parsedText.value = replaceEmojis(emoji, indices, trimmed)
             continue
           }
         }
@@ -66,12 +76,11 @@ const loadTwemojify = async () => {
         }
       }
     }
-    parsedText.value = replaceEmojis(emoji, indices)
+    parsedText.value = replaceEmojis(emoji, indices, trimmed)
   }
 }
 
 watch(() => props, async () => {
-  parsedText.value = props.text
   await loadTwemojify()
 }, { deep: true })
 

--- a/src/runtime/components/Twemojify.vue
+++ b/src/runtime/components/Twemojify.vue
@@ -30,14 +30,11 @@ const replaceEmojis = (emoji: string, indices: number[], source: string) => {
 
 const loadTwemojify = async () => {
   const trimmed = removeVS16s(props.text)
-  console.log('props.text: ', props.text)
   parsedText.value = trimmed
 
   const emojis = parse(props.text, { assetType: renderMode.value })
-  console.log('emojis: ', emojis)
 
   for (const { url, indices, text: emoji } of emojis) {
-    console.log('url: ', url)
     if (!url) continue
 
     if (twemojify.value[emoji]) {

--- a/src/runtime/components/Twemojify.vue
+++ b/src/runtime/components/Twemojify.vue
@@ -4,7 +4,6 @@ import { ref, computed, watch } from 'vue'
 import { parse } from '@twemoji/parser'
 import type { NuxtTwemojiRuntimeOptions } from '../../types'
 import { useState, useRuntimeConfig } from '#imports'
-import { removeVS16s } from '../utils/parsing'
 
 const props = defineProps<{
   /**
@@ -23,6 +22,9 @@ const renderMode = computed(() => props.mode !== undefined ? props.mode : config
 const twemojify = useState(`twemojify:${renderMode.value}`, () => ({}) as Record<string, string>)
 const parsedText = ref(props.text)
 
+const vs16RegExp = /️/gu
+const removeVS16s = (text: string) => text.replace(vs16RegExp, '')
+
 const replaceEmojis = (emoji: string, indices: number[], source: string) => {
   if (!twemojify.value[emoji]) return parsedText.value
   return parsedText.value.replace(source.slice(...indices), twemojify.value[emoji])
@@ -32,7 +34,7 @@ const loadTwemojify = async () => {
   const trimmed = removeVS16s(props.text)
   parsedText.value = trimmed
 
-  const emojis = parse(props.text, { assetType: renderMode.value })
+  const emojis = parse(trimmed, { assetType: renderMode.value })
 
   for (const { url, indices, text: emoji } of emojis) {
     if (!url) continue

--- a/src/runtime/utils/parsing.ts
+++ b/src/runtime/utils/parsing.ts
@@ -1,6 +1,0 @@
-const vs16RegExp = /\uFE0F/g
-const zeroWidthJoiner = String.fromCharCode(0x200D)
-
-export const removeVS16s = (rawEmoji: string) => {
-  return !rawEmoji.includes(zeroWidthJoiner) ? rawEmoji.replace(vs16RegExp, '') : rawEmoji
-}

--- a/src/runtime/utils/parsing.ts
+++ b/src/runtime/utils/parsing.ts
@@ -1,0 +1,6 @@
+const vs16RegExp = /\uFE0F/g
+const zeroWidthJoiner = String.fromCharCode(0x200D)
+
+export const removeVS16s = (rawEmoji: string) => {
+  return !rawEmoji.includes(zeroWidthJoiner) ? rawEmoji.replace(vs16RegExp, '') : rawEmoji
+}

--- a/test/fixtures/basic/app/pages/Twemojify/vs16/png.vue
+++ b/test/fixtures/basic/app/pages/Twemojify/vs16/png.vue
@@ -1,0 +1,3 @@
+<template>
+  <Twemojify :text="`This has an invalid VS16 modifier ➡️ \u274C\uFE0F`" mode="png" />
+</template>

--- a/test/fixtures/basic/app/pages/Twemojify/vs16/svg.vue
+++ b/test/fixtures/basic/app/pages/Twemojify/vs16/svg.vue
@@ -1,0 +1,3 @@
+<template>
+  <Twemojify :text="`This has an invalid VS16 modifier ➡️ \u274C\uFE0F`" />
+</template>

--- a/test/twemojify.test.ts
+++ b/test/twemojify.test.ts
@@ -7,7 +7,7 @@ const expected = {
   img: 'I <img src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/2764.png" class="twemojify" /> Nuxt <img src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f680.png" class="twemojify" />',
   vs16: {
     svg: '<span>This has an invalid VS16 modifier <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="twemojify"><path fill="#3B88C3" d="M36 32c0 2.209-1.791 4-4 4H4c-2.209 0-4-1.791-4-4V4c0-2.209 1.791-4 4-4h28c2.209 0 4 1.791 4 4v28z"/><path fill="#FFF" d="M7 14h9V7l13 11-13 11v-7H7z"/></svg> <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="twemojify"><path fill="#DD2E44" d="M21.533 18.002L33.768 5.768c.976-.976.976-2.559 0-3.535-.977-.977-2.559-.977-3.535 0L17.998 14.467 5.764 2.233c-.976-.977-2.56-.977-3.535 0-.977.976-.977 2.559 0 3.535l12.234 12.234L2.201 30.265c-.977.977-.977 2.559 0 3.535.488.488 1.128.732 1.768.732s1.28-.244 1.768-.732l12.262-12.263 12.234 12.234c.488.488 1.128.732 1.768.732.64 0 1.279-.244 1.768-.732.976-.977.976-2.559 0-3.535L21.533 18.002z"/></svg></span>',
-    png: '<span>This has an invalid VS16 modifier <img src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/27a1.png" class="twemojify" /> <img src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/274c.png" class="twemojify" /></span>'
+    png: '<span>This has an invalid VS16 modifier <img src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/27a1.png" class="twemojify" /> <img src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/274c.png" class="twemojify" /></span>',
   },
 }
 

--- a/test/twemojify.test.ts
+++ b/test/twemojify.test.ts
@@ -5,6 +5,10 @@ import { setup, $fetch } from '@nuxt/test-utils'
 const expected = {
   svg: 'I <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="twemojify"><path fill="#DD2E44" d="M35.885 11.833c0-5.45-4.418-9.868-9.867-9.868-3.308 0-6.227 1.633-8.018 4.129-1.791-2.496-4.71-4.129-8.017-4.129-5.45 0-9.868 4.417-9.868 9.868 0 .772.098 1.52.266 2.241C1.751 22.587 11.216 31.568 18 34.034c6.783-2.466 16.249-11.447 17.617-19.959.17-.721.268-1.469.268-2.242z"/></svg> Nuxt <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="twemojify"><path fill="#A0041E" d="M1 17l8-7 16 1 1 16-7 8s.001-5.999-6-12-12-6-12-6z"/><path fill="#FFAC33" d="M.973 35s-.036-7.979 2.985-11S15 21.187 15 21.187 14.999 29 11.999 32c-3 3-11.026 3-11.026 3z"/><circle fill="#FFCC4D" cx="8.999" cy="27" r="4"/><path fill="#55ACEE" d="M35.999 0s-10 0-22 10c-6 5-6 14-4 16s11 2 16-4c10-12 10-22 10-22z"/><path d="M26.999 5c-1.623 0-3.013.971-3.641 2.36.502-.227 1.055-.36 1.641-.36 2.209 0 4 1.791 4 4 0 .586-.133 1.139-.359 1.64 1.389-.627 2.359-2.017 2.359-3.64 0-2.209-1.791-4-4-4z"/><path fill="#A0041E" d="M8 28s0-4 1-5 13.001-10.999 14-10-9.001 13-10.001 14S8 28 8 28z"/></svg>',
   img: 'I <img src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/2764.png" class="twemojify" /> Nuxt <img src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/1f680.png" class="twemojify" />',
+  vs16: {
+    svg: '<span>This has an invalid VS16 modifier <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="twemojify"><path fill="#3B88C3" d="M36 32c0 2.209-1.791 4-4 4H4c-2.209 0-4-1.791-4-4V4c0-2.209 1.791-4 4-4h28c2.209 0 4 1.791 4 4v28z"/><path fill="#FFF" d="M7 14h9V7l13 11-13 11v-7H7z"/></svg> <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="twemojify"><path fill="#DD2E44" d="M21.533 18.002L33.768 5.768c.976-.976.976-2.559 0-3.535-.977-.977-2.559-.977-3.535 0L17.998 14.467 5.764 2.233c-.976-.977-2.56-.977-3.535 0-.977.976-.977 2.559 0 3.535l12.234 12.234L2.201 30.265c-.977.977-.977 2.559 0 3.535.488.488 1.128.732 1.768.732s1.28-.244 1.768-.732l12.262-12.263 12.234 12.234c.488.488 1.128.732 1.768.732.64 0 1.279-.244 1.768-.732.976-.977.976-2.559 0-3.535L21.533 18.002z"/></svg></span>',
+    png: '<span>This has an invalid VS16 modifier <img src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/27a1.png" class="twemojify" /> <img src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/274c.png" class="twemojify" /></span>'
+  },
 }
 
 await setup({
@@ -20,5 +24,15 @@ describe('Twemojify component tests', () => {
   it('renders text with emojis as <img>', async () => {
     const html = await $fetch('/Twemojify/png')
     expect(html).toContain(expected.img)
+  })
+
+  it('renders text with emojis as <svg>, handling invalid VS16 modifiers', async () => {
+    const html = await $fetch('/Twemojify/vs16/svg')
+    expect(html).toContain(expected.vs16.svg)
+  })
+
+  it('renders text with emojis as <img>, handling invalid VS16 modifiers', async () => {
+    const html = await $fetch('/Twemojify/vs16/png')
+    expect(html).toContain(expected.vs16.png)
   })
 })


### PR DESCRIPTION
closes: #6 